### PR TITLE
recv() calls adjusted to align with each other on the connection

### DIFF
--- a/Client/Client.py
+++ b/Client/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/Client.py
+++ b/Client/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client1/Client.py
+++ b/Client/client1/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client1/Client.py
+++ b/Client/client1/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client2/Client.py
+++ b/Client/client2/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client2/Client.py
+++ b/Client/client2/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client3/Client.py
+++ b/Client/client3/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client3/Client.py
+++ b/Client/client3/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client4/Client.py
+++ b/Client/client4/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client4/Client.py
+++ b/Client/client4/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client5/Client.py
+++ b/Client/client5/Client.py
@@ -66,7 +66,7 @@ def sendEmail(clientSocket, cipherAES, username):
         return
     
     content = ''
-    if input("Would youlike to load contents from a file?(Y/N) ").upper() == 'Y':
+    if input("Would you like to load contents from a file?(Y/N) ").upper() == 'Y':
         fileName = input("Enter filename: ")
         try:
             with open(fileName, 'r') as f:
@@ -79,14 +79,14 @@ def sendEmail(clientSocket, cipherAES, username):
         content = input("Enter message contents: ")
     
     if len(content) > 1000000:
-        print("Content too long (max 1000000 characters)")
+        print("Contents too long (max 1000000 characters)")
         return
     
     email = f"From: {username}\n"
     email += f"To: {destinations}\n"
     email += f"Title: {title}\n"
     email += f"Content Length: {len(content)}\n"
-    email += f"Content:\n{content}"
+    email += f"Contents:\n{content}"
     
     encryptedEmail = cipherAES.encrypt(email.encode().ljust(4096))
     clientSocket.send(encryptedEmail)
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1024)
+        encryptedEmail = clientSocket.recv(4096)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Client/client5/Client.py
+++ b/Client/client5/Client.py
@@ -120,7 +120,7 @@ def viewEmail(clientSocket, cipherAES):
         encryptedIndex = cipherAES.encrypt(index.encode().ljust(1024))
         clientSocket.send(encryptedIndex)
         
-        encryptedEmail = clientSocket.recv(1000000)
+        encryptedEmail = clientSocket.recv(1024)
         email = cipherAES.decrypt(encryptedEmail).decode().strip()
         print(email + "\n")
 

--- a/Server/Server.py
+++ b/Server/Server.py
@@ -138,10 +138,16 @@ def viewEmailHandler(connectionSocket, cipherAES, username):
     inboxDir = os.path.join(serverDir, username)
     emailFiles = sorted(glob.glob(os.path.join(inboxDir, "*.txt")), key=os.path.getmtime)
     
-    if 1 <= index <= len(emailFiles):
-        with open(emailFiles[index-1], 'r') as f:
-            emailContent = f.read()
-        connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(4096)))
+    # invalid index selection
+    if not (1 <= index <= len(emailFiles)):
+        errorMsg = 'Error: Selected email index does not exist.'
+        connectionSocket.send(cipherAES.encrypt(errorMsg.encode().ljust(4096)))
+        return
+    
+    # open the email, send it to the client.
+    with open(emailFiles[index-1], 'r') as f:
+        emailContent = f.read()
+    connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(4096)))
 
 
 def handleClient(connectionSocket, clientPublicKeys, cipherRSA, userCredentials):

--- a/Server/Server.py
+++ b/Server/Server.py
@@ -141,7 +141,7 @@ def viewEmailHandler(connectionSocket, cipherAES, username):
     if 1 <= index <= len(emailFiles):
         with open(emailFiles[index-1], 'r') as f:
             emailContent = f.read()
-        connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(4096)))
+        connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(1024)))
 
 
 def handleClient(connectionSocket, clientPublicKeys, cipherRSA, userCredentials):

--- a/Server/Server.py
+++ b/Server/Server.py
@@ -141,7 +141,7 @@ def viewEmailHandler(connectionSocket, cipherAES, username):
     if 1 <= index <= len(emailFiles):
         with open(emailFiles[index-1], 'r') as f:
             emailContent = f.read()
-        connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(1024)))
+        connectionSocket.send(cipherAES.encrypt(emailContent.strip().encode().ljust(4096)))
 
 
 def handleClient(connectionSocket, clientPublicKeys, cipherRSA, userCredentials):


### PR DESCRIPTION
recv(bufferSize) buffer sizes were adjusted to align with each other.
Misaligned buffer sizes, especially for viewing email protocol #3, would cause the client to crash by reading bytes that didn't exist.

## recv(1024)
- 1024 Bytes (1KB)
- Use for small data streams, like the "OK" acknowledgment, menu/index selections

## recv(4096)
- 4096 Bytes (4KB)
- handles larger chunks of data to reduce the sysCalls and overhead required to stream larger datasets such as emails.
- buffer sizes that are too large and don't align with each other waste memory and can hang if data does not arrive quickly enough.

reference to sockets 
- https://docs.python.org/3.6/howto/sockets.html#using-a-socket